### PR TITLE
add log message when keys do not contain '/'

### DIFF
--- a/src/ngx_stream_upsync_module.c
+++ b/src/ngx_stream_upsync_module.c
@@ -1155,7 +1155,12 @@ ngx_stream_upsync_consul_parse_json(void *data)
         cJSON *temp1 = cJSON_GetObjectItem(server_next, "Key");
         if (temp1 != NULL && temp1->valuestring != NULL) {
             p = (u_char *)ngx_strrchr(temp1->valuestring, '/');
-            if (p == NULL || ngx_stream_upsync_check_key(p) != NGX_OK) {
+            if (p == NULL) {
+                ngx_log_error(NGX_LOG_ERR, ngx_cycle->log, 0,
+                              "upsync_parse_json: %s key format is illegal, "
+                              "contains no slash ('/')", temp1->valuestring);
+                continue;
+            } else if (ngx_stream_upsync_check_key(p) != NGX_OK) {
                 continue;
             }
 
@@ -1389,7 +1394,12 @@ ngx_stream_upsync_etcd_parse_json(void *data)
         cJSON *temp0 = cJSON_GetObjectItem(server_next, "key");
         if (temp0 != NULL && temp0->valuestring != NULL) {
             p = (u_char *)ngx_strrchr(temp0->valuestring, '/');
-            if (p == NULL || ngx_stream_upsync_check_key(p) != NGX_OK) {
+            if (p == NULL) {
+                ngx_log_error(NGX_LOG_ERR, ngx_cycle->log, 0,
+                              "upsync_parse_json: %s key format is illegal, "
+                              "contains no slash ('/')", temp0->valuestring);
+                continue;
+            } else if (ngx_stream_upsync_check_key(p) != NGX_OK) {
                 continue;
             }
 


### PR DESCRIPTION
hi @xiaokai-wang please check if this is OK. As discussed I could not move the check to ngx_stream_upsync_check_key() as printing the key wasn't possible there. So I stuck to your initial suggestion. 

I have made the changes lined up for nginx-upsync-module as well (master and nginx-upsync-1.9.x branches).

I have tested the change in nginx-upsync-1.9.x branch with consul.