### PR TITLE
Update to nginx 1.12

### DIFF
--- a/src/ngx_stream_upsync_module.c
+++ b/src/ngx_stream_upsync_module.c
@@ -299,6 +299,7 @@ static ngx_command_t  ngx_stream_upsync_commands[] = {
 
 
 static ngx_stream_module_t  ngx_stream_upsync_module_ctx = {
+    NULL,
     NULL,                                       /* postconfiguration */
 
     ngx_stream_upsync_create_main_conf,         /* create main configuration */
@@ -3728,7 +3729,7 @@ ngx_stream_upsync_show(ngx_stream_session_t *s)
         ngx_log_error(NGX_LOG_ERR, s->connection->log, 0, 
                       "alloc upsync_show buf failed");
 
-        ngx_stream_close_connection(s->connection);
+        ngx_stream_finalize_session(s, NGX_STREAM_OK);
         return;
     }
 
@@ -3757,7 +3758,7 @@ ngx_stream_upsync_show(ngx_stream_session_t *s)
     ngx_stream_upsync_show_send(s, b_header); //send header
     ngx_stream_upsync_show_send(s, b_body); //send body
 
-    ngx_stream_close_connection(s->connection);
+    ngx_stream_finalize_session(s, NGX_STREAM_OK);
 
     return;
 }


### PR DESCRIPTION
Fixes to compile on 1.12 if we want to support that already?
Main nginx-upstream-module seems to compile just fine :)