### PR TITLE
bugfix for ngx_stream_upsync_del_peers

### DIFF
--- a/src/ngx_stream_upsync_module.c
+++ b/src/ngx_stream_upsync_module.c
@@ -1115,7 +1115,10 @@ ngx_stream_upsync_del_peers(ngx_cycle_t *cycle,
             pre_peer = peer;
         }
     }
-    tmp_del_peer->next = NULL;
+
+    if (tmp_del_peer) {
+        tmp_del_peer->next = NULL;
+    }
 
     peers->single = (n == 1);
     peers->number = n;


### PR DESCRIPTION
bugfix: 解决在删除peer 时，无匹配项 引发空指针引用产生的coredump