### PR TITLE
bugfix: coredump when set upsync_lb  hash_ketama

### DIFF
--- a/src/ngx_stream_upsync_module.h
+++ b/src/ngx_stream_upsync_module.h
@@ -67,6 +67,7 @@ typedef struct {
 
 
 typedef struct {
+    ngx_stream_complex_value_t            key;
     ngx_stream_upstream_chash_points_t   *points;
 } ngx_stream_upstream_hash_srv_conf_t;
 


### PR DESCRIPTION
struct ngx_stream_upstream_hash_srv_conf_t  should be same with the one in ngx_stream_upstream_hash_module.
when I  use hash_ketama, it will couse coredump, because hcf got the wrong offset data